### PR TITLE
grapheneos: Fix for QPR2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,13 @@
+# DISCLAIMER
+
+THIS IS A FORK OF MAGISK THAT FIXES ZYGISK ON GRAPHENEOS.
+
+BY USING THIS FORK, YOU AGREE THAT YOU TRUST THE AUTHOR OF THIS FORK AND THAT YOU WILL NOT HOLD THE AUTHOR RESPONSIBLE FOR ANY DAMAGES OR LOSSES INCURRED AS A RESULT OF USING THIS FORK.
+
+MAKE SURE THAT YOU HAVE CHECKED THE SOURCE CODE AND UNDERSTAND WHAT IT DOES BEFORE USING IT.
+
+---
+
 ![](docs/images/logo.png)
 
 [![Downloads](https://img.shields.io/badge/dynamic/json?color=green&label=Downloads&query=totalString&url=https%3A%2F%2Fraw.githubusercontent.com%2Ftopjohnwu%2Fmagisk-files%2Fcount%2Fcount.json&cacheSeconds=1800)](https://raw.githubusercontent.com/topjohnwu/magisk-files/count/count.json)

--- a/native/src/core/zygisk/gen_jni_hooks.py
+++ b/native/src/core/zygisk/gen_jni_hooks.py
@@ -90,6 +90,7 @@ jintArray = JArray(jint)
 jstring = JType("jstring", "Ljava/lang/String;")
 jboolean = JType("jboolean", "Z")
 jlong = JType("jlong", "J")
+jlongArray = JArray(jlong)
 void = JType("void", "V")
 
 
@@ -407,6 +408,32 @@ fas_samsung_p = ForkApp(
     ],
 )
 
+fas_grapheneos_u = ForkApp(
+    "grapheneos_u",
+    [
+        uid,
+        gid,
+        gids,
+        runtime_flags,
+        rlimits,
+        mount_external,
+        se_info,
+        nice_name,
+        fds_to_close,
+        fds_to_ignore,
+        is_child_zygote,
+        instruction_set,
+        app_data_dir,
+        is_top_app,
+        pkg_data_info_list,
+        whitelisted_data_info_list,
+        mount_data_dirs,
+        mount_storage_dirs,
+        mount_sysprop_overrides,
+        Anon(jlongArray),
+    ],
+)
+
 spec_q = SpecializeApp(
     "q",
     [
@@ -506,6 +533,30 @@ spec_samsung_q = SpecializeApp(
     ],
 )
 
+spec_grapheneos_u = SpecializeApp(
+    "grapheneos_u",
+    [
+        uid,
+        gid,
+        gids,
+        runtime_flags,
+        rlimits,
+        mount_external,
+        se_info,
+        nice_name,
+        is_child_zygote,
+        instruction_set,
+        app_data_dir,
+        is_top_app,
+        pkg_data_info_list,
+        whitelisted_data_info_list,
+        mount_data_dirs,
+        mount_storage_dirs,
+        mount_sysprop_overrides,
+        Anon(jlongArray),
+    ],
+)
+
 server_l = ForkServer(
     "l",
     [
@@ -528,6 +579,19 @@ server_samsung_q = ForkServer(
         runtime_flags,
         Anon(jint),
         Anon(jint),
+        rlimits,
+        permitted_capabilities,
+        effective_capabilities,
+    ],
+)
+
+server_grapheneos_u = ForkServer(
+    "grapheneos_u",
+    [
+        uid,
+        gid,
+        gids,
+        runtime_flags,
         rlimits,
         permitted_capabilities,
         effective_capabilities,
@@ -575,6 +639,7 @@ with open("jni_hooks.hpp", "w") as f:
                 fas_samsung_n,
                 fas_samsung_o,
                 fas_samsung_p,
+                fas_grapheneos_u,
             ],
         )
     )
@@ -582,10 +647,14 @@ with open("jni_hooks.hpp", "w") as f:
     f.write(
         gen_jni_def(
             "specialize_app_methods",
-            [spec_q, spec_q_alt, spec_r, spec_u, spec_samsung_q],
+            [spec_q, spec_q_alt, spec_r, spec_u, spec_samsung_q, spec_grapheneos_u],
         )
     )
 
-    f.write(gen_jni_def("fork_server_methods", [server_l, server_samsung_q]))
+    f.write(
+        gen_jni_def(
+            "fork_server_methods", [server_l, server_samsung_q, server_grapheneos_u]
+        )
+    )
 
     f.write("\n};\n")

--- a/native/src/core/zygisk/gen_jni_hooks.py
+++ b/native/src/core/zygisk/gen_jni_hooks.py
@@ -425,6 +425,7 @@ fas_grapheneos_u = ForkApp(
         instruction_set,
         app_data_dir,
         is_top_app,
+        Anon(jboolean),  # use_fifo_ui
         pkg_data_info_list,
         whitelisted_data_info_list,
         mount_data_dirs,

--- a/native/src/core/zygisk/jni_hooks.hpp
+++ b/native/src/core/zygisk/jni_hooks.hpp
@@ -207,8 +207,8 @@ std::array<JNINativeMethod, 12> fork_app_methods = {{
     // nativeForkAndSpecialize_grapheneos_u
     {
         "nativeForkAndSpecialize",
-        "(II[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)I",
-        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9) static -> jint {
+        "(II[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;ZZ[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)I",
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jboolean use_fifo_ui, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9) static -> jint {
             AppSpecializeArgs_v5 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
             args.fds_to_ignore = &fds_to_ignore;
             args.is_child_zygote = &is_child_zygote;
@@ -220,8 +220,8 @@ std::array<JNINativeMethod, 12> fork_app_methods = {{
             args.mount_sysprop_overrides = &mount_sysprop_overrides;
             ZygiskContext ctx(env, &args);
             ctx.nativeForkAndSpecialize_pre();
-            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9)>(get_defs()->fork_app_methods[11].fnPtr)(
-                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _9
+            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jboolean use_fifo_ui, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9)>(get_defs()->fork_app_methods[11].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, use_fifo_ui, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _9
             );
             ctx.nativeForkAndSpecialize_post();
             return ctx.pid;

--- a/native/src/core/zygisk/jni_hooks.hpp
+++ b/native/src/core/zygisk/jni_hooks.hpp
@@ -6,7 +6,7 @@ static JniHookDefinitions *get_defs();
 
 struct JniHookDefinitions {
 
-std::array<JNINativeMethod, 11> fork_app_methods = {{
+std::array<JNINativeMethod, 12> fork_app_methods = {{
     // nativeForkAndSpecialize_l
     {
         "nativeForkAndSpecialize",
@@ -204,9 +204,32 @@ std::array<JNINativeMethod, 11> fork_app_methods = {{
             return ctx.pid;
         }
     },
+    // nativeForkAndSpecialize_grapheneos_u
+    {
+        "nativeForkAndSpecialize",
+        "(II[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)I",
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9) static -> jint {
+            AppSpecializeArgs_v5 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
+            args.fds_to_ignore = &fds_to_ignore;
+            args.is_child_zygote = &is_child_zygote;
+            args.is_top_app = &is_top_app;
+            args.pkg_data_info_list = &pkg_data_info_list;
+            args.whitelisted_data_info_list = &whitelisted_data_info_list;
+            args.mount_data_dirs = &mount_data_dirs;
+            args.mount_storage_dirs = &mount_storage_dirs;
+            args.mount_sysprop_overrides = &mount_sysprop_overrides;
+            ZygiskContext ctx(env, &args);
+            ctx.nativeForkAndSpecialize_pre();
+            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _9)>(get_defs()->fork_app_methods[11].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _9
+            );
+            ctx.nativeForkAndSpecialize_post();
+            return ctx.pid;
+        }
+    },
 }};
 
-std::array<JNINativeMethod, 5> specialize_app_methods = {{
+std::array<JNINativeMethod, 6> specialize_app_methods = {{
     // nativeSpecializeAppProcess_q
     {
         "nativeSpecializeAppProcess",
@@ -283,20 +306,41 @@ std::array<JNINativeMethod, 5> specialize_app_methods = {{
     {
         "nativeSpecializeAppProcess",
         "(II[II[[IILjava/lang/String;IILjava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V",
-        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _9, jint _10, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir) static -> void {
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _10, jint _11, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir) static -> void {
             AppSpecializeArgs_v5 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
             args.is_child_zygote = &is_child_zygote;
             ZygiskContext ctx(env, &args);
             ctx.nativeSpecializeAppProcess_pre();
-            reinterpret_cast<void(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _9, jint _10, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir)>(get_defs()->specialize_app_methods[4].fnPtr)(
-                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, _9, _10, nice_name, is_child_zygote, instruction_set, app_data_dir
+            reinterpret_cast<void(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _10, jint _11, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir)>(get_defs()->specialize_app_methods[4].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, _10, _11, nice_name, is_child_zygote, instruction_set, app_data_dir
+            );
+            ctx.nativeSpecializeAppProcess_post();
+        }
+    },
+    // nativeSpecializeAppProcess_grapheneos_u
+    {
+        "nativeSpecializeAppProcess",
+        "(II[II[[IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)V",
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _12) static -> void {
+            AppSpecializeArgs_v5 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
+            args.is_child_zygote = &is_child_zygote;
+            args.is_top_app = &is_top_app;
+            args.pkg_data_info_list = &pkg_data_info_list;
+            args.whitelisted_data_info_list = &whitelisted_data_info_list;
+            args.mount_data_dirs = &mount_data_dirs;
+            args.mount_storage_dirs = &mount_storage_dirs;
+            args.mount_sysprop_overrides = &mount_sysprop_overrides;
+            ZygiskContext ctx(env, &args);
+            ctx.nativeSpecializeAppProcess_pre();
+            reinterpret_cast<void(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _12)>(get_defs()->specialize_app_methods[5].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _12
             );
             ctx.nativeSpecializeAppProcess_post();
         }
     },
 }};
 
-std::array<JNINativeMethod, 2> fork_server_methods = {{
+std::array<JNINativeMethod, 3> fork_server_methods = {{
     // nativeForkSystemServer_l
     {
         "nativeForkSystemServer",
@@ -316,12 +360,27 @@ std::array<JNINativeMethod, 2> fork_server_methods = {{
     {
         "nativeForkSystemServer",
         "(II[IIII[[IJJ)I",
-        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _11, jint _12, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities) static -> jint {
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _13, jint _14, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities) static -> jint {
             ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, permitted_capabilities, effective_capabilities);
             ZygiskContext ctx(env, &args);
             ctx.nativeForkSystemServer_pre();
-            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _11, jint _12, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities)>(get_defs()->fork_server_methods[1].fnPtr)(
-                env, clazz, uid, gid, gids, runtime_flags, _11, _12, rlimits, permitted_capabilities, effective_capabilities
+            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _13, jint _14, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities)>(get_defs()->fork_server_methods[1].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, _13, _14, rlimits, permitted_capabilities, effective_capabilities
+            );
+            ctx.nativeForkSystemServer_post();
+            return ctx.pid;
+        }
+    },
+    // nativeForkSystemServer_grapheneos_u
+    {
+        "nativeForkSystemServer",
+        "(II[II[[IJJ)I",
+        (void *) +[] [[clang::no_stack_protector]] (JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities) static -> jint {
+            ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, permitted_capabilities, effective_capabilities);
+            ZygiskContext ctx(env, &args);
+            ctx.nativeForkSystemServer_pre();
+            reinterpret_cast<jint(*)(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities)>(get_defs()->fork_server_methods[2].fnPtr)(
+                env, clazz, uid, gid, gids, runtime_flags, rlimits, permitted_capabilities, effective_capabilities
             );
             ctx.nativeForkSystemServer_post();
             return ctx.pid;


### PR DESCRIPTION
## Description

QPR2 [changes](https://github.com/topjohnwu/Magisk/commit/0936cdb192fa3c5353527168fd9bbfef99714ed4) to Magisk introduced `use_fifo_ui` and this was not being used by Graphene signatures. this pr aims to address that. 

The changes to AOSP are basically meant to improve UI responsiveness by giving the UI thread higher priority.

Relevant Google AOSP commit: https://android.googlesource.com/platform/frameworks/base.git/+/67a4b1b2fee385f798d75ad02d016b80fc79f075

Fixes https://github.com/pixincreate/Magisk/issues/19