### PR TITLE
feat(app): hide direct install and uninstall when bootloader is locked

### DIFF
--- a/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/home/HomeScreen.kt
+++ b/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/home/HomeScreen.kt
@@ -230,10 +230,12 @@ fun HomeScreen(viewModel: HomeViewModel, installVm: InstallViewModel) {
                 onHideRestorePressed = viewModel::onHideRestorePressed,
             )
 
-            UninstallButton(
-                onClick = { viewModel.onDeletePressed() },
-                enabled = Info.env.isActive
-            )
+            if (!Info.isBootloaderLocked) {
+                UninstallButton(
+                    onClick = { viewModel.onDeletePressed() },
+                    enabled = Info.env.isActive
+                )
+            }
 
             Text(
                 text = stringResource(CoreR.string.home_support_title),

--- a/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallBottomSheet.kt
+++ b/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallBottomSheet.kt
@@ -130,7 +130,7 @@ fun InstallBottomSheet(
                     },
                 )
 
-                if (installVm.isRooted) {
+                if (installVm.isRooted && !installVm.isBootloaderLocked) {
                     SettingsArrow(
                         title = stringResource(CoreR.string.direct_install),
                         summary = stringResource(CoreR.string.direct_install_summary),

--- a/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallBottomSheet.kt
+++ b/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallBottomSheet.kt
@@ -129,7 +129,7 @@ fun InstallBottomSheet(
                     },
                 )
 
-                if (installVm.isRooted) {
+                if (installVm.isRooted && !installVm.isBootloaderLocked) {
                     SettingsArrow(
                         title = stringResource(CoreR.string.direct_install),
                         onClick = {

--- a/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -115,6 +115,9 @@ class InstallViewModel(svc: NetworkService) : BaseViewModel() {
     }
 
     fun install() {
+        if (isBootloaderLocked &&
+            (_uiState.value.method == Method.DIRECT || _uiState.value.method == Method.INACTIVE_SLOT)
+        ) return
         when (_uiState.value.method) {
             Method.PATCH -> navigateTo(Route.Flash(
                 action = Const.Value.PATCH_FILE,

--- a/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk-ng/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -38,8 +38,9 @@ class InstallViewModel(svc: NetworkService) : BaseViewModel() {
     )
 
     val isRooted get() = Info.isRooted
+    val isBootloaderLocked get() = Info.isBootloaderLocked
     val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && Info.ramdisk)
-    val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator
+    val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator || isBootloaderLocked
 
     private val _uiState = MutableStateFlow(UiState(step = if (skipOptions) 1 else 0))
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -38,8 +38,9 @@ import com.topjohnwu.magisk.core.R as CoreR
 class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() {
 
     val isRooted get() = Info.isRooted
+    val isBootloaderLocked get() = Info.isBootloaderLocked
     val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && Info.ramdisk)
-    val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator
+    val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator || isBootloaderLocked
 
     @get:Bindable
     var step = if (skipOptions) 1 else 0

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -95,6 +95,9 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
     }
 
     fun install() {
+        if (Info.isBootloaderLocked &&
+            (method == R.id.method_direct || method == R.id.method_inactive_slot)
+        ) return
         when (method) {
             R.id.method_patch -> FlashFragment.patch(data.value!!).navigate(true)
             R.id.method_download -> FlashFragment.download(data.value!!).navigate(true)
@@ -118,7 +121,9 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
 
     override fun onRestoreState(state: Bundle) {
         state.getParcelable<InstallState>(INSTALL_STATE_KEY)?.let {
-            methodId = it.method
+            methodId = if (Info.isBootloaderLocked &&
+                (it.method == R.id.method_direct || it.method == R.id.method_inactive_slot)
+            ) -1 else it.method
             step = it.step
             Config.keepVerity = it.keepVerity
             Config.keepEnc = it.keepEnc

--- a/app/apk/src/main/res/layout/fragment_home_md2.xml
+++ b/app/apk/src/main/res/layout/fragment_home_md2.xml
@@ -114,7 +114,7 @@
 
             <Button
                 style="@style/WidgetFoundation.Button.Outlined.Error"
-                goneUnless="@{Info.env.isActive}"
+                gone="@{!Info.env.isActive || Info.isBootloaderLocked}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/l1"

--- a/app/apk/src/main/res/layout/fragment_home_md2.xml
+++ b/app/apk/src/main/res/layout/fragment_home_md2.xml
@@ -108,7 +108,7 @@
                 app:layout_constraintTop_toBottomOf="@+id/home_magisk_wrapper" />
 
             <Space
-                goneUnless="@{Info.env.isActive}"
+                gone="@{!Info.env.isActive || Info.isBootloaderLocked}"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/l1" />
 

--- a/app/apk/src/main/res/layout/fragment_install_md2.xml
+++ b/app/apk/src/main/res/layout/fragment_install_md2.xml
@@ -200,7 +200,7 @@
                         <RadioButton
                             android:id="@+id/method_direct"
                             style="@style/WidgetFoundation.RadioButton"
-                            gone="@{!viewModel.rooted}"
+                            gone="@{!viewModel.rooted || Info.isBootloaderLocked}"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:text="@string/direct_install" />

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -60,11 +60,10 @@ object Info {
             || getProperty("ro.kernel.qemu", "0") == "1"
             || getProperty("ro.boot.qemu", "0") == "1"
 
-    @JvmStatic val isBootloaderLocked: Boolean
-        get() {
-            val state = getProperty("ro.boot.vbmeta.device_state", "")
-            if (state.isNotEmpty()) return state == "locked"
-            return getProperty("ro.boot.flash.locked", "0") == "1"
+    @JvmStatic val isBootloaderLocked: Boolean =
+        getProperty("ro.boot.vbmeta.device_state", "").let { state ->
+            if (state.isNotEmpty()) state.equals("locked", ignoreCase = true)
+            else getProperty("ro.boot.flash.locked", "0") == "1"
         }
 
     val isConnected = MutableLiveData(false)

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -60,6 +60,13 @@ object Info {
             || getProperty("ro.kernel.qemu", "0") == "1"
             || getProperty("ro.boot.qemu", "0") == "1"
 
+    @JvmStatic val isBootloaderLocked: Boolean
+        get() {
+            val state = getProperty("ro.boot.vbmeta.device_state", "")
+            if (state.isNotEmpty()) return state == "locked"
+            return getProperty("ro.boot.flash.locked", "0") == "1"
+        }
+
     val isConnected = MutableLiveData(false)
 
     val showSuperUser: Boolean get() {


### PR DESCRIPTION
Closes #28

Detect bootloader lock state via system properties (`ro.boot.vbmeta.device_state`) and restrict risky operations:

- **Hide Direct Install** — writing to boot partition on a locked bootloader risks softbrick
- **Hide Install to Inactive Slot** — same risk as Direct Install
- **Hide Uninstall** — uninstalling Magisk on a locked bootloader is unrecoverable without OEM unlock

**Still available**: Select and Patch a File, Download and Patch a File, install options (keep_verity, keep_enc, recovery_mode) — these produce a patched image file that the user handles externally.

Changes apply to both the new Compose UI (`apk-ng`) and the legacy Fragment UI (`apk`).